### PR TITLE
Implement responsive layout

### DIFF
--- a/frontend/src/app/landing/landing-page.component.scss
+++ b/frontend/src/app/landing/landing-page.component.scss
@@ -36,3 +36,18 @@
 .cta-button:hover {
   transform: scale(1.05);
 }
+
+@media (max-width: 768px) {
+  .hero {
+    min-height: 50vh;
+  }
+
+  .overlay h1,
+  .overlay p {
+    font-size: 70%;
+  }
+
+  .cta-button {
+    font-size: 0.7rem;
+  }
+}

--- a/frontend/src/app/preferences/preferences.component.scss
+++ b/frontend/src/app/preferences/preferences.component.scss
@@ -24,6 +24,7 @@ button.active {
   background-color: $color-accent;
 }
 
+
 .slider-wrapper {
   display: flex;
   align-items: center;
@@ -33,4 +34,18 @@ button.active {
 .nav-buttons {
   display: flex;
   justify-content: space-between;
+}
+
+@media (max-width: 768px) {
+  .preferences-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .toggle-group {
+    flex-direction: column;
+  }
+
+  .toggle-group button {
+    width: 100%;
+  }
 }

--- a/frontend/src/app/shared/header.component.html
+++ b/frontend/src/app/shared/header.component.html
@@ -1,5 +1,11 @@
 <nav class="navbar">
   <a class="logo" routerLink="/">Travel Planner</a>
+  <input id="nav-toggle" class="nav-toggle" type="checkbox" />
+  <label for="nav-toggle" class="hamburger">
+    <span></span>
+    <span></span>
+    <span></span>
+  </label>
   <ul class="nav-links">
     <li><a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Home</a></li>
     <li><a routerLink="/preferences" routerLinkActive="active">Preferences</a></li>

--- a/frontend/src/app/shared/header.component.scss
+++ b/frontend/src/app/shared/header.component.scss
@@ -10,6 +10,7 @@
   background: #fff;
   border-bottom: 1px solid #ccc;
   z-index: 1000;
+  position: relative;
 }
 
 .nav-links {
@@ -27,4 +28,49 @@
 
 .nav-links a.active {
   color: $color-accent;
+}
+
+.nav-toggle {
+  display: none;
+}
+
+.hamburger {
+  display: none;
+  flex-direction: column;
+  cursor: pointer;
+  span {
+    width: 25px;
+    height: 3px;
+    background: #333;
+    margin: 4px 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .hamburger {
+    display: flex;
+  }
+
+  .nav-links {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background: #fff;
+    flex-direction: column;
+    gap: 0;
+    width: 100%;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+    border-bottom: 1px solid #ccc;
+  }
+
+  .nav-links li {
+    padding: 0.5rem 0;
+    text-align: center;
+  }
+
+  .nav-toggle:checked ~ .hamburger + .nav-links {
+    max-height: 200px;
+  }
 }


### PR DESCRIPTION
## Summary
- reduce hero height and font sizes on small screens
- switch preferences grid layout to single column on mobile
- convert header to hamburger menu on small screens

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc7e858f88331a3b36cf94b0544f4