### PR TITLE
Add component animations and accessibility

### DIFF
--- a/frontend/src/app/landing/landing-page.component.html
+++ b/frontend/src/app/landing/landing-page.component.html
@@ -2,6 +2,15 @@
   <div class="overlay">
     <h1>Dein nächstes Abenteuer wartet</h1>
     <p>Entdecke die Welt ganz nach deinen Vorlieben.</p>
-    <button routerLink="/preferences" class="cta-button">Jetzt Präferenzen wählen</button>
+    <button
+      routerLink="/preferences"
+      class="cta-button"
+      aria-label="Präferenzen wählen"
+      (mouseenter)="hoverState='hover'"
+      (mouseleave)="hoverState='rest'"
+      [@pulse]="hoverState"
+    >
+      Jetzt Präferenzen wählen
+    </button>
   </div>
 </div>

--- a/frontend/src/app/landing/landing-page.component.scss
+++ b/frontend/src/app/landing/landing-page.component.scss
@@ -37,6 +37,11 @@
   transform: scale(1.05);
 }
 
+.cta-button:focus {
+  outline: 2px solid $color-accent;
+  outline-offset: 2px;
+}
+
 @media (max-width: 768px) {
   .hero {
     min-height: 50vh;

--- a/frontend/src/app/landing/landing-page.component.ts
+++ b/frontend/src/app/landing/landing-page.component.ts
@@ -1,11 +1,44 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import {
+  trigger,
+  transition,
+  style,
+  animate,
+  state,
+  keyframes
+} from '@angular/animations';
 
 @Component({
   selector: 'app-landing-page',
   standalone: true,
   imports: [RouterLink],
   templateUrl: './landing-page.component.html',
-  styleUrl: './landing-page.component.scss'
+  styleUrl: './landing-page.component.scss',
+  animations: [
+    trigger('fadeIn', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('500ms ease-in', style({ opacity: 1 }))
+      ])
+    ]),
+    trigger('pulse', [
+      state('rest', style({ transform: 'scale(1)' })),
+      state('hover', style({ transform: 'scale(1)' })),
+      transition('rest => hover', [
+        animate(
+          '500ms ease-in-out',
+          keyframes([
+            style({ transform: 'scale(1)', offset: 0 }),
+            style({ transform: 'scale(1.1)', offset: 0.5 }),
+            style({ transform: 'scale(1)', offset: 1 })
+          ])
+        )
+      ])
+    ])
+  ],
+  host: { '[@fadeIn]': '' }
 })
-export class LandingPageComponent {}
+export class LandingPageComponent {
+  hoverState = 'rest';
+}

--- a/frontend/src/app/preferences/preferences.component.html
+++ b/frontend/src/app/preferences/preferences.component.html
@@ -2,16 +2,60 @@
   <div class="toggle-section">
     <label>Reiseziel</label>
     <div class="toggle-group">
-      <button type="button" (click)="setDestination('sea')" [class.active]="form.value.destinationType === 'sea'">🌊 Meer</button>
-      <button type="button" (click)="setDestination('mountain')" [class.active]="form.value.destinationType === 'mountain'">🏔️ Berge</button>
+      <button
+        type="button"
+        aria-label="Reiseziel Meer wählen"
+        (click)="setDestination('sea')"
+        (keydown.space)="setDestination('sea')"
+        [class.active]="form.value.destinationType === 'sea'"
+        (mouseenter)="onEnter('sea')"
+        (mouseleave)="onLeave()"
+        [@pulse]="hovered === 'sea' ? 'hover' : 'rest'"
+      >
+        🌊 Meer
+      </button>
+      <button
+        type="button"
+        aria-label="Reiseziel Berge wählen"
+        (click)="setDestination('mountain')"
+        (keydown.space)="setDestination('mountain')"
+        [class.active]="form.value.destinationType === 'mountain'"
+        (mouseenter)="onEnter('mountain')"
+        (mouseleave)="onLeave()"
+        [@pulse]="hovered === 'mountain' ? 'hover' : 'rest'"
+      >
+        🏔️ Berge
+      </button>
     </div>
   </div>
 
   <div class="toggle-section">
     <label>Klima</label>
     <div class="toggle-group">
-      <button type="button" (click)="setClimate('warm')" [class.active]="form.value.climate === 'warm'">☀️ Warm</button>
-      <button type="button" (click)="setClimate('cold')" [class.active]="form.value.climate === 'cold'">❄️ Kalt</button>
+      <button
+        type="button"
+        aria-label="Klima warm wählen"
+        (click)="setClimate('warm')"
+        (keydown.space)="setClimate('warm')"
+        [class.active]="form.value.climate === 'warm'"
+        (mouseenter)="onEnter('warm')"
+        (mouseleave)="onLeave()"
+        [@pulse]="hovered === 'warm' ? 'hover' : 'rest'"
+      >
+        ☀️ Warm
+      </button>
+      <button
+        type="button"
+        aria-label="Klima kalt wählen"
+        (click)="setClimate('cold')"
+        (keydown.space)="setClimate('cold')"
+        [class.active]="form.value.climate === 'cold'"
+        (mouseenter)="onEnter('cold')"
+        (mouseleave)="onLeave()"
+        [@pulse]="hovered === 'cold' ? 'hover' : 'rest'"
+      >
+        ❄️ Kalt
+      </button>
     </div>
   </div>
 
@@ -25,7 +69,28 @@
   </div>
 
   <div class="nav-buttons">
-    <button routerLink="/" type="button" class="nav-btn">Zurück</button>
-    <button type="button" (click)="onNext()" class="nav-btn">Weiter</button>
+    <button
+      routerLink="/"
+      type="button"
+      class="nav-btn"
+      aria-label="Zurück zur Startseite"
+      (mouseenter)="onEnter('back')"
+      (mouseleave)="onLeave()"
+      [@pulse]="hovered === 'back' ? 'hover' : 'rest'"
+    >
+      Zurück
+    </button>
+    <button
+      type="button"
+      class="nav-btn"
+      aria-label="Weiter"
+      (click)="onNext()"
+      (keydown.space)="onNext()"
+      (mouseenter)="onEnter('next')"
+      (mouseleave)="onLeave()"
+      [@pulse]="hovered === 'next' ? 'hover' : 'rest'"
+    >
+      Weiter
+    </button>
   </div>
 </form>

--- a/frontend/src/app/preferences/preferences.component.scss
+++ b/frontend/src/app/preferences/preferences.component.scss
@@ -24,6 +24,12 @@ button.active {
   background-color: $color-accent;
 }
 
+button:focus,
+.nav-btn:focus {
+  outline: 2px solid $color-accent;
+  outline-offset: 2px;
+}
+
 
 .slider-wrapper {
   display: flex;

--- a/frontend/src/app/preferences/preferences.component.ts
+++ b/frontend/src/app/preferences/preferences.component.ts
@@ -2,16 +2,48 @@ import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import {
+  trigger,
+  transition,
+  style,
+  animate,
+  state,
+  keyframes
+} from '@angular/animations';
 
 @Component({
   selector: 'app-preferences',
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule, RouterLink],
   templateUrl: './preferences.component.html',
-  styleUrl: './preferences.component.scss'
+  styleUrl: './preferences.component.scss',
+  animations: [
+    trigger('fadeIn', [
+      transition(':enter', [
+        style({ opacity: 0 }),
+        animate('500ms ease-in', style({ opacity: 1 }))
+      ])
+    ]),
+    trigger('pulse', [
+      state('rest', style({ transform: 'scale(1)' })),
+      state('hover', style({ transform: 'scale(1)' })),
+      transition('rest => hover', [
+        animate(
+          '500ms ease-in-out',
+          keyframes([
+            style({ transform: 'scale(1)', offset: 0 }),
+            style({ transform: 'scale(1.1)', offset: 0.5 }),
+            style({ transform: 'scale(1)', offset: 1 })
+          ])
+        )
+      ])
+    ])
+  ],
+  host: { '[@fadeIn]': '' }
 })
 export class PreferencesComponent {
   form: FormGroup;
+  hovered = 'rest';
 
   constructor(private fb: FormBuilder) {
     this.form = this.fb.group({
@@ -19,6 +51,14 @@ export class PreferencesComponent {
       climate: [''],
       experienceLevel: [5]
     });
+  }
+
+  onEnter(id: string) {
+    this.hovered = id;
+  }
+
+  onLeave() {
+    this.hovered = 'rest';
   }
 
   setDestination(type: string) {


### PR DESCRIPTION
## Summary
- animate landing and preferences pages with fade-in and button pulse on hover
- add aria-labels and keyboard handling for all buttons
- improve focus outlines with accent color

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc8e8492c8331b5cb385bb162788a