### PR TITLE
Extend preferences form

### DIFF
--- a/frontend/src/app/preferences/preferences.component.html
+++ b/frontend/src/app/preferences/preferences.component.html
@@ -68,6 +68,64 @@
     </div>
   </div>
 
+  <div class="input-section">
+    <label for="residency">Wohnort <span class="required">*</span></label>
+    <input id="residency" type="text" formControlName="residency" list="city-list" />
+    <datalist id="city-list">
+      <option value="Berlin"></option>
+      <option value="Hamburg"></option>
+      <option value="München"></option>
+      <option value="Köln"></option>
+      <option value="Stuttgart"></option>
+    </datalist>
+    <div class="error" *ngIf="form.get('residency')?.touched && form.get('residency')?.errors?.['required']">
+      Residency erforderlich
+    </div>
+  </div>
+
+  <div class="input-section">
+    <label for="budget">Budget</label>
+    <div class="budget-wrapper">
+      <input id="budget" type="number" formControlName="budget" min="0" />
+      <span class="suffix">€</span>
+    </div>
+  </div>
+
+  <div class="input-section">
+    <label for="tripType">Reiseart</label>
+    <select id="tripType" formControlName="tripType">
+      <option value="">-- Bitte wählen --</option>
+      <option value="mountains">Mountains</option>
+      <option value="beach">Beach</option>
+      <option value="city">City</option>
+    </select>
+  </div>
+
+  <div class="slider-section">
+    <label>Dauer (Tage)</label>
+    <div class="slider-wrapper">
+      <span>1</span>
+      <input type="range" formControlName="durationDays" min="1" max="30" />
+      <span>30</span>
+    </div>
+  </div>
+
+  <div class="slider-section">
+    <label>Temperatur (°C)</label>
+    <div class="slider-wrapper">
+      <span>-10</span>
+      <input type="range" formControlName="temperature" min="-10" max="40" list="temp-list" />
+      <datalist id="temp-list">
+        <option value="0"></option>
+        <option value="10"></option>
+        <option value="20"></option>
+        <option value="30"></option>
+        <option value="40"></option>
+      </datalist>
+      <span>40</span>
+    </div>
+  </div>
+
   <div class="nav-buttons">
     <button
       routerLink="/"

--- a/frontend/src/app/preferences/preferences.component.scss
+++ b/frontend/src/app/preferences/preferences.component.scss
@@ -42,6 +42,31 @@ button:focus,
   justify-content: space-between;
 }
 
+.input-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.budget-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.suffix {
+  color: $color-secondary;
+}
+
+.error {
+  color: red;
+  font-size: 0.8rem;
+}
+
+.required {
+  color: red;
+}
+
 @media (max-width: 768px) {
   .preferences-grid {
     grid-template-columns: 1fr;

--- a/frontend/src/app/preferences/preferences.component.ts
+++ b/frontend/src/app/preferences/preferences.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import {
@@ -49,7 +49,12 @@ export class PreferencesComponent {
     this.form = this.fb.group({
       destinationType: [''],
       climate: [''],
-      experienceLevel: [5]
+      experienceLevel: [5],
+      residency: ['', Validators.required],
+      budget: [null],
+      tripType: [''],
+      durationDays: [1],
+      temperature: [15]
     });
   }
 


### PR DESCRIPTION
## Summary
- collect more trip details in `PreferencesComponent` reactive form
- add inputs for residency, budget and trip type
- add sliders for duration and temperature
- style the new form fields

## Testing
- `npm install`
- `npm test` *(fails: No Chrome binary found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ee7a99848331847f654dfb95c03c