### PR TITLE
Add SuggestionService with models

### DIFF
--- a/frontend/src/app/core/models/destination.ts
+++ b/frontend/src/app/core/models/destination.ts
@@ -1,0 +1,6 @@
+export interface Destination {
+  id: string;
+  name: string;
+  imageUrl: string;
+  score: number;
+}

--- a/frontend/src/app/core/models/preferences.ts
+++ b/frontend/src/app/core/models/preferences.ts
@@ -1,0 +1,10 @@
+export interface Preferences {
+  destinationType: string;
+  climate: string;
+  experienceLevel: number;
+  residency: string;
+  budget: number | null;
+  tripType: string;
+  durationDays: number;
+  temperature: number;
+}

--- a/frontend/src/app/core/services/suggestion.service.ts
+++ b/frontend/src/app/core/services/suggestion.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Preferences } from '../models/preferences';
+import { Destination } from '../models/destination';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SuggestionService {
+  constructor(private http: HttpClient) {}
+
+  getSuggestions(prefs: Preferences): Observable<Destination[]> {
+    return this.http.post<Destination[]>('/api/suggestions', prefs);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `SuggestionService` for fetching destination suggestions
- define `Preferences` and `Destination` models

## Testing
- `npm test` *(fails: No binary for Chrome)*