### PR TITLE
Add navigation for results and history

### DIFF
--- a/frontend/src/app/shared/header.component.html
+++ b/frontend/src/app/shared/header.component.html
@@ -21,10 +21,17 @@
     </li>
     <li>
       <a
+        routerLink="/results"
+        routerLinkActive="active"
+        [routerLinkActiveOptions]="{ exact: true }"
+      >Ergebnisse</a>
+    </li>
+    <li>
+      <a
         routerLink="/history"
         routerLinkActive="active"
         [routerLinkActiveOptions]="{ exact: true }"
-      >History</a>
+      >Verlauf</a>
     </li>
     <li>
       <a

--- a/frontend/src/app/shared/header.component.scss
+++ b/frontend/src/app/shared/header.component.scss
@@ -21,6 +21,10 @@
   margin: 0;
 }
 
+.nav-links li {
+  list-style: none;
+}
+
 .nav-links a {
   text-decoration: none;
   color: inherit;


### PR DESCRIPTION
## Summary
- add missing navigation links for Ergebnisse and Verlauf
- style `li` elements in header nav

## Testing
- `npx -p @angular/cli ng test --watch=false --browsers=ChromeHeadless` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6860fbfc06048331a1a9a86dc4ce20a0